### PR TITLE
Add puppet_enterprise::profile::agent to the common role

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -45,3 +45,4 @@ At a minimum, you will want to supply the following parameters to the `puppet_en
 
 ## Additional Usage:
  - By default the console's ENC will be disabled for all masters, but you can re-enable it on a per-master basis by supplying the `disable_console_enc` value via hiera, in scope for one or all masters. If set to `false`, the console ENC will be enabled.
+ - If the `disable_console_enc` param is set to `true` (default), you may optionally specify a custom value for the `node_terminus` setting in puppet.conf by setting the `node_terminus` value in hiera.  Otherwise the `node_terminus` value will be set to `plain`.

--- a/manifests/profile/master.pp
+++ b/manifests/profile/master.pp
@@ -1,5 +1,6 @@
 class lei_wrapper::profile::master {
   $disable_console_enc = hiera('disable_console_enc', true)
+  $node_terminus = hiera('node_terminus', 'plain')
 
   if $disable_console_enc == true {
     class { 'puppet_enterprise::profile::master':
@@ -10,7 +11,7 @@ class lei_wrapper::profile::master {
       path    => '/etc/puppetlabs/puppet/puppet.conf',
       section => 'master',
       setting => 'node_terminus',
-      value   => 'plain',
+      value   => $node_terminus,
       notify  => Service['pe-puppetserver']
     }
   }

--- a/manifests/role/common.pp
+++ b/manifests/role/common.pp
@@ -1,5 +1,6 @@
 class lei_wrapper::role::common {
   include lei_wrapper::params
   include puppet_enterprise
+  include puppet_enterprise::profile::agent
   include puppet_enterprise::profile::mcollective::agent
 }


### PR DESCRIPTION
In PE 3.8, all agent nodes should be assigned the puppet_enterprise::profile::agent role which manages the "convenience" symlinks for facter, puppet, etc.  The lei_wrapper::role::common class has been updated to include this.
